### PR TITLE
Add a sample executable that hogs up all the CPU

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,6 +12,8 @@ RUN mkdir -p $TB3_OVERLAY_WS/src
 WORKDIR $TB3_OVERLAY_WS
 COPY .docker/overlay.repos ./
 RUN vcs import src < overlay.repos
+# extra package from this repo
+COPY example_nodes src/
 # RUN vcs import src < src/ros-planning/navigation2/tools/ros2_dependencies.repos
 
 # install overlay package dependencies

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,39 +6,6 @@ RUN rosdep update && \
     apt-get purge python3-rosdep -y && \
     pip3 install git+https://github.com/ruffsl/rosdep.git@ament
 
-# clone overlay package repos
-ENV TB3_OVERLAY_WS /opt/tb3_overlay_ws
-RUN mkdir -p $TB3_OVERLAY_WS/src
-WORKDIR $TB3_OVERLAY_WS
-COPY .docker/overlay.repos ./
-RUN vcs import src < overlay.repos
-# extra package from this repo
-COPY example_nodes src/
-# RUN vcs import src < src/ros-planning/navigation2/tools/ros2_dependencies.repos
-
-# install overlay package dependencies
-RUN . /opt/ros/$ROS_DISTRO/setup.sh && \
-    apt-get update && apt-get install -y \
-      ros-$ROS_DISTRO-turtlebot3-cartographer \
-      ros-$ROS_DISTRO-turtlebot3-navigation2 \
-      ros-$ROS_DISTRO-turtlebot3-simulations \
-      ros-$ROS_DISTRO-turtlebot3-teleop \
-    && rosdep install -y \
-      --from-paths \
-        src \
-      --ignore-src \
-        --skip-keys "\
-            ament_mypy \
-            libopensplice69 \
-            rti-connext-dds-5.3.1" \
-    && rm -rf /var/lib/apt/lists/*
-
-# build overlay package source
-# RUN touch $TB3_OVERLAY_WS/src/turtlebot3/turtlebot3_node/COLCON_IGNORE
-RUN . /opt/ros/$ROS_DISTRO/setup.sh && \
-    colcon build \
-      --symlink-install
-
 # install helpful developer tools
 RUN apt-get update && apt-get install -y \
       bash-completion \
@@ -51,6 +18,42 @@ RUN apt-get update && apt-get install -y \
       vim \
     && cd /usr/bin && curl https://getmic.ro | bash \
     && rm -rf /var/lib/apt/lists/*
+
+# install turtlebot external packages
+RUN apt-get update && apt-get install -y \
+      ros-$ROS_DISTRO-turtlebot3-cartographer \
+      ros-$ROS_DISTRO-turtlebot3-navigation2 \
+      ros-$ROS_DISTRO-turtlebot3-simulations \
+      ros-$ROS_DISTRO-turtlebot3-teleop \
+    && rm -rf /var/lib/apt/lists/*
+
+# clone overlay package repos
+ENV TB3_OVERLAY_WS /opt/tb3_overlay_ws
+RUN mkdir -p $TB3_OVERLAY_WS/src
+WORKDIR $TB3_OVERLAY_WS
+COPY .docker/overlay.repos ./
+RUN vcs import src < overlay.repos
+# Install extra sources from this repo
+COPY example_nodes/ src/example_nodes
+# RUN vcs import src < src/ros-planning/navigation2/tools/ros2_dependencies.repos
+
+# install overlay package dependencies
+RUN . /opt/ros/$ROS_DISTRO/setup.sh \
+    && rosdep install -y \
+      --from-paths src \
+      --ignore-src \
+      --skip-keys " \
+            ament_mypy \
+            libopensplice69 \
+            rti-connext-dds-5.3.1 \
+        " \
+    && rm -rf /var/lib/apt/lists/*
+
+# build overlay package source
+# RUN touch $TB3_OVERLAY_WS/src/turtlebot3/turtlebot3_node/COLCON_IGNORE
+RUN . /opt/ros/$ROS_DISTRO/setup.sh && \
+    colcon build \
+      --symlink-install
 
 # generate artifacts for keystore
 ENV TB3_DEMO_DIR $TB3_OVERLAY_WS/..

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ Byobu starts a new session and launch the turtlebot3 demo over several windows:
 * `diagnostic`
   * glance overview of containerized processes
 
-You can first localize the robot by initializing the pose and then setting a navigation goal via the scripts in the respective window pains. This can also be done graphically via rviz. Feel free to poke around, open a new window and list or echo topics and services. For example, you can stop the navigation2 launch file running map server and and start cartographer from the mapping window to create and then save your own map, then stop cartographer and restart navigation2.
+You can first localize the robot by initializing the pose and then setting a navigation goal via the scripts in the respective window panes. This can also be done graphically via rviz. Feel free to poke around, open a new window and list or echo topics and services. For example, you can stop the navigation2 launch file running map server and and start cartographer from the mapping window to create and then save your own map, then stop cartographer and restart navigation2.
 
 [![](media/localize.png)](media/localize.mp4)
 
@@ -141,27 +141,17 @@ export ROS_SECURITY_ENABLE=true
 
 Now try starting another teleop node with security disabled and check that only the secure teleop node can drive the robot.
 
-# Security Workshop Sandbox Node Demo
+## Sandboxed Nodes Demo
 
 The [ROSCon 2019](https://ros-swg.github.io/ROSCon19_Security_Workshop/) [ROS2 Security Workshop](https://ros-swg.github.io/ROSCon19_Security_Workshop/)
 will present the opportunity to run the Turtlebot3 demo using the [launch-ros-sandbox](https://github.com/aws-robotics/launch-ros-sandbox)
 package. Specifically, the demo uses this package to launch the Turtlebot3 navigation nodes in a docker container. See the
 configs/sandbox_demo/navigation_sandbox.launch.py launch file for details.
 
-## Running the Security Workshop Sandbox Node Demo
-
-Build the docker image required using the dockerfile from this repository
+### Running the Security Workshop Sandbox Node Demo
 
 ``` bash
-git clone git@github.com:ros-swg/turtlebot3_demo.git
-cd turtlebot3_demo
-docker build . -t ros-swg/turtlebot3_demo
-```
-
-Once the image is built, we can run it with the following command:
-
-``` bash
-rocker --x11 --nvidia ros-swg/turtlebot3_demo "byobu -f configs/sandbox_demo/unsecure.conf attach"
+rocker --x11 --nvidia rosswg/turtlebot3_demo "byobu -f configs/sandbox_demo/unsecure.conf attach"
 ```
 
 Omit the `--nvidia` arg if you don't have dedicated GPU for hardware acceleration of 3D OpenGL views.
@@ -169,8 +159,7 @@ Omit the `--nvidia` arg if you don't have dedicated GPU for hardware acceleratio
 Likewise, the following command is used to run the demo using the secure config:
 
 ``` bash
-
-rocker --x11 --nvidia  rosswg/turtlebot3_sandbox_demo "byobu -f configs/sandbox_demo/secure.conf attach"
+rocker --x11 --nvidia  rosswg/turtlebot3_demo "byobu -f configs/sandbox_demo/secure.conf attach"
 ```
 
 ### Demonstrating Sandbox Resource Limits
@@ -186,4 +175,12 @@ This is a contrived example - but it illustrates what could happen if a node tha
 If you run the command, you can see the CPU of your system jump to 100% usage, grinding everything else to a halt.
 
 UPCOMING: Show usage of `launch_ros_sandbox` resource limits to keep the demo running happily.
->>>>>>> Add argument for how many processes, and document how to use
+
+## Developing
+To rebuild this demo locally if you are working on it, you can rebuild the Docker image with the same tag, so all above demo commands will work correctly.
+
+``` bash
+git clone git@github.com:ros-swg/turtlebot3_demo.git
+cd turtlebot3_demo
+docker build . -t rosswg/turtlebot3_demo
+```

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ To run this demo using docker, the following dependencies are required:
 * [rocker](https://github.com/osrf/rocker)
   * Please ensure display forwarding is working with rocker.
   * [nvidia-docker](https://github.com/NVIDIA/nvidia-docker) is also useful for those with a GPU.
-  
+
   For those who can't use linux containers or for detailed instructions on how to build, you may still follow the general build steps of the [Dockerfile](Dockerfile).
 
 ## Running the demo:
@@ -70,7 +70,7 @@ export ROS_SECURITY_ROOT_DIRECTORY=$TB3_DEMO_DIR/keystore
 export ROS_SECURITY_LOOKUP_TYPE=MATCH_PREFIX
 ```
 
-These variables simply enable as well as enforce security for all ros2 nodes while specifying the lookup path/strategy for loading key and access control artifacts. For more details on what secure options exist and what each is for, please view the design doc here: 
+These variables simply enable as well as enforce security for all ros2 nodes while specifying the lookup path/strategy for loading key and access control artifacts. For more details on what secure options exist and what each is for, please view the design doc here:
 
 * https://design.ros2.org/articles/ros2_dds_security.html
 
@@ -129,7 +129,7 @@ Next we can repopulated the keystore for all profiles via:
 ``` bash
 ros2 security generate_artifacts \
   -p policy/my_policy.xml \
-  -k keystore 
+  -k keystore
 ```
 
 Finally, go back and re-enable security and restart simulation and the teleop nodes.
@@ -145,7 +145,7 @@ Now try starting another teleop node with security disabled and check that only 
 
 The [ROSCon 2019](https://ros-swg.github.io/ROSCon19_Security_Workshop/) [ROS2 Security Workshop](https://ros-swg.github.io/ROSCon19_Security_Workshop/)
 will present the opportunity to run the Turtlebot3 demo using the [launch-ros-sandbox](https://github.com/aws-robotics/launch-ros-sandbox)
-package. Specifically, the demo uses this package to launch the Turtlebot3 navigation nodes in a docker container. See the 
+package. Specifically, the demo uses this package to launch the Turtlebot3 navigation nodes in a docker container. See the
 configs/sandbox_demo/navigation_sandbox.launch.py launch file for details.
 
 ## Running the Security Workshop Sandbox Node Demo
@@ -155,13 +155,13 @@ Build the docker image required using the dockerfile from this repository
 ``` bash
 git clone git@github.com:ros-swg/turtlebot3_demo.git
 cd turtlebot3_demo
-docker build . -t rosswg:turtlebot3_sandbox_demo
+docker build . -t ros-swg/turtlebot3_demo
 ```
 
 Once the image is built, we can run it with the following command:
 
 ``` bash
-rocker --x11 --nvidia rosswg:turtlebot3_sandbox_demo "byobu -f configs/sandbox_demo/unsecure.conf attach"
+rocker --x11 --nvidia ros-swg/turtlebot3_demo "byobu -f configs/sandbox_demo/unsecure.conf attach"
 ```
 
 Omit the `--nvidia` arg if you don't have dedicated GPU for hardware acceleration of 3D OpenGL views.
@@ -169,5 +169,21 @@ Omit the `--nvidia` arg if you don't have dedicated GPU for hardware acceleratio
 Likewise, the following command is used to run the demo using the secure config:
 
 ``` bash
-rocker --x11 --nvidia  rosswg:turtlebot3_sandbox_demo "byobu -f configs/sandbox_demo/secure.conf attach"
+
+rocker --x11 --nvidia  rosswg/turtlebot3_sandbox_demo "byobu -f configs/sandbox_demo/secure.conf attach"
 ```
+
+### Demonstrating Sandbox Resource Limits
+
+This demo shows how robot code, acting improperly, can negatively affect the entire robotic system.
+
+``` bash
+rocker --x11 --nvidia rosswg/turtlebot3_demo "byobu -f configs/sandbox_demo/bad_actor.conf attach"
+```
+
+After launching with the above config, there is a command ready in the `bad_actor` byobu window, ready to run a cpu hog that will fork many busy processes (`ros2 run example_nodes cpu_hog 8`).
+This is a contrived example - but it illustrates what could happen if a node that you are using hits an untested code path and goes into an infinite loop.
+If you run the command, you can see the CPU of your system jump to 100% usage, grinding everything else to a halt.
+
+UPCOMING: Show usage of `launch_ros_sandbox` resource limits to keep the demo running happily.
+>>>>>>> Add argument for how many processes, and document how to use

--- a/configs/sandbox_demo/bad_actor.conf
+++ b/configs/sandbox_demo/bad_actor.conf
@@ -1,0 +1,12 @@
+source $BYOBU_PREFIX/share/byobu/profiles/tmux
+
+# setup secure session
+new-session -s secure -n diagnostic -d
+send-keys 'glances' Enter
+
+setenv FOO "foo"
+
+source configs/sandbox_demo/security_workshop_demo_common.conf
+
+new-window -n bad_actor
+send-keys 'ros2 run example_nodes cpu_hog 8'

--- a/example_nodes/CMakeLists.txt
+++ b/example_nodes/CMakeLists.txt
@@ -1,0 +1,40 @@
+cmake_minimum_required(VERSION 3.5)
+project(example_nodes)
+
+# Default to C99
+if(NOT CMAKE_C_STANDARD)
+  set(CMAKE_C_STANDARD 99)
+endif()
+
+# Default to C++14
+if(NOT CMAKE_CXX_STANDARD)
+  set(CMAKE_CXX_STANDARD 14)
+endif()
+
+if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+  add_compile_options(-Wall -Wextra -Wpedantic)
+endif()
+
+# find dependencies
+find_package(ament_cmake REQUIRED)
+find_package(rcutils REQUIRED)
+
+add_executable(cpu_hog src/cpu_hog.cpp)
+target_include_directories(cpu_hog PUBLIC
+  $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+  $<INSTALL_INTERFACE:include>)
+ament_target_dependencies(
+  cpu_hog
+  "rcutils"
+)
+
+install(TARGETS cpu_hog
+  EXPORT export_${PROJECT_NAME}
+  DESTINATION lib/${PROJECT_NAME})
+
+if(BUILD_TESTING)
+  find_package(ament_lint_auto REQUIRED)
+  ament_lint_auto_find_test_dependencies()
+endif()
+
+ament_package()

--- a/example_nodes/package.xml
+++ b/example_nodes/package.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0"?>
+<?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="3">
+  <name>example_nodes</name>
+  <version>0.0.0</version>
+  <description>Example nodes for the ROSCon 2019 security workshop</description>
+  <maintainer email="ros-contributions@amazon.com">AWS RoboMaker</maintainer>
+  <license>Apache 2.0</license>
+
+  <buildtool_depend>ament_cmake</buildtool_depend>
+
+  <depend>rcutils</depend>
+
+  <test_depend>ament_lint_auto</test_depend>
+  <test_depend>ament_lint_common</test_depend>
+
+  <export>
+    <build_type>ament_cmake</build_type>
+  </export>
+</package>

--- a/example_nodes/src/cpu_hog.cpp
+++ b/example_nodes/src/cpu_hog.cpp
@@ -1,0 +1,87 @@
+// Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <errno.h>
+#include <math.h>
+#include <string.h>
+#include <unistd.h>
+#include <sys/wait.h>
+#include <cstdio>
+#include <cstdlib>
+#include <memory>
+#include <random>
+
+#include "rcutils/logging_macros.h"
+
+/* Fork some threads to hog the CPU */
+int start_hogs(uint forks)
+{
+  int pid, retval = 0;
+  uint i;
+  double d;
+
+  for (i = 0; forks == 0 || i < forks; i++) {
+    switch (pid = fork()) {
+      case 0:  // If I'm the child fork
+        // Use a backoff sleep to ensure we get good fork throughput.
+        usleep(3000);
+
+        // Do meaningless work!
+        while (1) {
+          d = sqrt(std::rand());
+        }
+      // This case never falls through, it works forever (until parent is exited)
+      case -1:
+        RCUTILS_LOG_ERROR("Worker fork failed.");
+        return 1;
+      default:
+        // I'm the parent fork
+        RCUTILS_LOG_INFO("--> Worker forked (%i)", pid);
+    }
+  }
+  (void) d;  // For the linter
+
+  // Wait for all child forks to exit
+  while (i) {
+    int status, ret;
+
+    if ((pid = wait(&status)) > 0) {
+      if ((WIFEXITED(status)) != 0) {
+        if ((ret = WEXITSTATUS(status)) != 0) {
+          RCUTILS_LOG_INFO("Worker process %i exited %i", pid, ret);
+          retval += ret;
+        } else {
+          RCUTILS_LOG_INFO("<-- Worker exited (%i)", pid);
+        }
+      } else {
+        RCUTILS_LOG_INFO("<-- Worker signalled (%i)", pid);
+      }
+
+      --i;
+    } else {
+      RCUTILS_LOG_INFO("wait() returned error: %s", strerror(errno));
+      RCUTILS_LOG_ERROR("detected missing hogcpu worker children");
+      ++retval;
+      break;
+    }
+  }
+
+  return retval;
+}
+
+
+int main(int /* argc */, char ** /* argv */)
+{
+  return start_hogs(4);
+}

--- a/example_nodes/src/cpu_hog.cpp
+++ b/example_nodes/src/cpu_hog.cpp
@@ -81,7 +81,19 @@ int start_hogs(uint forks)
 }
 
 
-int main(int /* argc */, char ** /* argv */)
+int main(int argc, char ** argv)
 {
-  return start_hogs(4);
+  int num_processes = 4;
+  if (argc == 2) {
+    num_processes = atoi(argv[1]);
+  } else if (argc > 2) {
+    RCUTILS_LOG_ERROR("Usage: cpu_hog [NUM_PROCESSES]");
+    return 1;
+  }
+  if (num_processes <= 0) {
+    RCUTILS_LOG_ERROR("NUM_PROCESSES must be greater than 0");
+    return 1;
+  }
+  RCUTILS_LOG_INFO("Forking %d cpu hogs", num_processes);
+  return start_hogs(num_processes);
 }


### PR DESCRIPTION
* Add a new `ament_cmake` ROS2 package `example_nodes`
* Create a process that hogs a configurable amount of CPU by forking busy processes
* Copy the new package into the Dockerfile so it is built
* Reorder the Dockerfile a little so it is more friendly to rebuild when code is changed
* Add instructions in README for a demo that makes everything slow to a crawl (and fix up some existing issues in the sandbox instructions)