### PR TITLE
Give an example of limiting the CPU of the cpu_hog bad actor

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,7 +174,7 @@ After launching with the above config, there are two commands ready in the `bad_
 They are ready to run a cpu hog that will fork many busy processes.
 This is a contrived example - but it illustrates what could happen if a node that you are using hits an untested code path and goes into an infinite loop.
 
-If you run the top command (`ros2 run...`), you can see the CPU of your system jump to 100% usage, grinding everything else to a halt.
+If you run the top command (`ros2 run...`), you can see the CPU of your system jump to 100% usage (check the `diagnostic` byobu window), grinding everything else to a halt.
 
 However, if you kill that and run the bottom command (`ros2 launch ...`), it will launch inside a container that has a CPU resource limit set.
 This launch will be able to use at most 2 CPUs worth of processing, allowing the rest of the demo to still run at a normal speed.

--- a/README.md
+++ b/README.md
@@ -170,11 +170,16 @@ This demo shows how robot code, acting improperly, can negatively affect the ent
 rocker --x11 --nvidia rosswg/turtlebot3_demo "byobu -f configs/sandbox_demo/bad_actor.conf attach"
 ```
 
-After launching with the above config, there is a command ready in the `bad_actor` byobu window, ready to run a cpu hog that will fork many busy processes (`ros2 run example_nodes cpu_hog 8`).
+After launching with the above config, there are two commands ready in the `bad_actor` byobu window.
+They are ready to run a cpu hog that will fork many busy processes.
 This is a contrived example - but it illustrates what could happen if a node that you are using hits an untested code path and goes into an infinite loop.
-If you run the command, you can see the CPU of your system jump to 100% usage, grinding everything else to a halt.
 
-UPCOMING: Show usage of `launch_ros_sandbox` resource limits to keep the demo running happily.
+If you run the top command (`ros2 run...`), you can see the CPU of your system jump to 100% usage, grinding everything else to a halt.
+
+However, if you kill that and run the bottom command (`ros2 launch ...`), it will launch inside a container that has a CPU resource limit set.
+This launch will be able to use at most 2 CPUs worth of processing, allowing the rest of the demo to still run at a normal speed.
+See `example_nodes/launch/sandboxed_cpu_hog.launch.py` for some more info on the arguments that make this happen.
+
 
 ## Developing
 To rebuild this demo locally if you are working on it, you can rebuild the Docker image with the same tag, so all above demo commands will work correctly.

--- a/configs/sandbox_demo/bad_actor.conf
+++ b/configs/sandbox_demo/bad_actor.conf
@@ -9,4 +9,7 @@ setenv FOO "foo"
 source configs/sandbox_demo/security_workshop_demo_common.conf
 
 new-window -n bad_actor
-send-keys 'ros2 run example_nodes cpu_hog 8'
+send-keys 'ros2 run example_nodes cpu_hog 32'
+
+split-window -v
+send-keys 'ros2 launch example_nodes sandboxed_cpu_hog.launch.py'

--- a/example_nodes/CMakeLists.txt
+++ b/example_nodes/CMakeLists.txt
@@ -32,6 +32,10 @@ install(TARGETS cpu_hog
   EXPORT export_${PROJECT_NAME}
   DESTINATION lib/${PROJECT_NAME})
 
+install(DIRECTORY
+  launch
+  DESTINATION share/${PROJECT_NAME}/)
+
 if(BUILD_TESTING)
   find_package(ament_lint_auto REQUIRED)
   ament_lint_auto_find_test_dependencies()

--- a/example_nodes/launch/sandboxed_cpu_hog.launch.py
+++ b/example_nodes/launch/sandboxed_cpu_hog.launch.py
@@ -22,6 +22,9 @@ disrupt the performance of the navigation demo.
 
 For more details please see the launch_ros_sandbox project at
 https://github.com/aws-robotics/launch-ros-sandbox
+
+For more information on configurable resource limits, see the `docker run` documentation
+https://docs.docker.com/engine/reference/run/#runtime-constraints-on-resources
 """
 import os
 
@@ -41,11 +44,14 @@ def generate_launch_description():
         arguments=['32'],
     )
     container = SandboxedNodeContainer(
-        sandbox_name='bad_actor',
+        sandbox_name='bad_actor_sandbox',
         policy=DockerPolicy(
             tag='roscon19',
             repository='rosswg/turtlebot3_demo',
-            container_name='turtlebot3_navigation',
+            container_name='bad_actor',
+            # run_args={
+            #     'cpus': '8',
+            # }
         ),
         node_descriptions=[node],
     )

--- a/example_nodes/launch/sandboxed_cpu_hog.launch.py
+++ b/example_nodes/launch/sandboxed_cpu_hog.launch.py
@@ -1,0 +1,53 @@
+# Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+This launchfile demonstrates resource limitations on sandboxed nodes.
+
+It spins up a program that tries to fork 32 simultaneous processes that each take up as much
+CPU time as possible.
+However, due to the constraints put on this node by the sandbox, it is not able to significantly
+disrupt the performance of the navigation demo.
+
+For more details please see the launch_ros_sandbox project at
+https://github.com/aws-robotics/launch-ros-sandbox
+"""
+import os
+
+from launch import LaunchDescription
+
+from launch_ros_sandbox.actions import SandboxedNodeContainer
+from launch_ros_sandbox.descriptions import DockerPolicy
+from launch_ros_sandbox.descriptions import SandboxedNode
+
+TURTLEBOT3_MODEL = os.environ['TURTLEBOT3_MODEL']
+
+
+def generate_launch_description():
+    node = SandboxedNode(
+        package='example_nodes',
+        node_executable='cpu_hog',
+        arguments=['32'],
+    )
+    container = SandboxedNodeContainer(
+        sandbox_name='bad_actor',
+        policy=DockerPolicy(
+            tag='roscon19',
+            repository='rosswg/turtlebot3_demo',
+            container_name='turtlebot3_navigation',
+        ),
+        node_descriptions=[node],
+    )
+
+    return LaunchDescription([container])

--- a/example_nodes/package.xml
+++ b/example_nodes/package.xml
@@ -11,6 +11,8 @@
 
   <depend>rcutils</depend>
 
+  <exec_depend>launch_ros_sandbox</exec_depend>
+
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>
 

--- a/example_nodes/src/cpu_hog.cpp
+++ b/example_nodes/src/cpu_hog.cpp
@@ -83,7 +83,7 @@ int start_hogs(uint forks)
 
 int main(int argc, char ** argv)
 {
-  int num_processes = 4;
+  int num_processes = 32;
   if (argc == 2) {
     num_processes = atoi(argv[1]);
   } else if (argc > 2) {


### PR DESCRIPTION
Add a new launchfile that shows how to apply a CPU constraint on a sandboxed node. Update documentation and byobu config to show how to use it.